### PR TITLE
add target framework net8.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4.1.1
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3.0.3
+      uses: actions/setup-dotnet@v4.0.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore  ./src/libfintx.sln
     - name: Build

--- a/src/libfintx.Database/libfintx.Database.csproj
+++ b/src/libfintx.Database/libfintx.Database.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/libfintx.EBICSConfig/libfintx.EBICSConfig.csproj
+++ b/src/libfintx.EBICSConfig/libfintx.EBICSConfig.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libfintx.FinTS/libfintx.FinTS.csproj
+++ b/src/libfintx.FinTS/libfintx.FinTS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libfintx.FinTSConfig/libfintx.FinTSConfig.csproj
+++ b/src/libfintx.FinTSConfig/libfintx.FinTSConfig.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libfintx.Globals/libfintx.Globals.csproj
+++ b/src/libfintx.Globals/libfintx.Globals.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/libfintx.Logger/libfintx.Logger.csproj
+++ b/src/libfintx.Logger/libfintx.Logger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libfintx.Sample.Database/libfintx.Sample.Database.csproj
+++ b/src/libfintx.Sample.Database/libfintx.Sample.Database.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>libfintx.Sample.Database</RootNamespace>
     <AssemblyName>libfintx.Sample.Database</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/libfintx.Sample.Ui/libfintx.Sample.Ui.csproj
+++ b/src/libfintx.Sample.Ui/libfintx.Sample.Ui.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>libfintx_test</RootNamespace>
     <AssemblyName>libfintx_test</AssemblyName>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/src/libfintx.Sample/libfintx.Sample.csproj
+++ b/src/libfintx.Sample/libfintx.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libfintx.Samples.INIFile/libfintx.Samples.INIFile.csproj
+++ b/src/libfintx.Samples.INIFile/libfintx.Samples.INIFile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/libfintx.Security/libfintx.Security.csproj
+++ b/src/libfintx.Security/libfintx.Security.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/libfintx.Sepa/libfintx.Sepa.csproj
+++ b/src/libfintx.Sepa/libfintx.Sepa.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libfintx.Settings/libfintx.Settings.csproj
+++ b/src/libfintx.Settings/libfintx.Settings.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/libfintx.Tests/libfintx.Tests.csproj
+++ b/src/libfintx.Tests/libfintx.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/libfintx.Xml/libfintx.Xml.csproj
+++ b/src/libfintx.Xml/libfintx.Xml.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libfintx/libfintx.csproj
+++ b/src/libfintx/libfintx.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Company>Torsten Klinger</Company>
     <Description>C# based client library for HBCI 2.2, FinTS 3.0, EBICS H004 and EBICS H005.</Description>
     <Copyright>Copyright © 2016 - 2022 Torsten Klinger</Copyright>


### PR DESCRIPTION
This adds .NET 8.0 as additional target framework + switches all executables to use .NET 8.0.

The reason to publish a library for several frameworks and to switch the compiler to .NET 8.0 is that we can benefit from the [Performance Improvements in .NET 8](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/).