### PR TITLE
removing unused references

### DIFF
--- a/src/libfintx.EBICS/libfintx.EBICS.csproj
+++ b/src/libfintx.EBICS/libfintx.EBICS.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\libfintx.EBICSConfig\libfintx.EBICSConfig.csproj" />
-    <ProjectReference Include="..\libfintx.Security\libfintx.Security.csproj" />
     <ProjectReference Include="..\libfintx.Xml\libfintx.Xml.csproj" />
   </ItemGroup>
 

--- a/src/libfintx.FinTS/libfintx.FinTS.csproj
+++ b/src/libfintx.FinTS/libfintx.FinTS.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\libfintx.FinTSConfig\libfintx.FinTSConfig.csproj" />
     <ProjectReference Include="..\libfintx.Globals\libfintx.Globals.csproj" />
     <ProjectReference Include="..\libfintx.Logger\libfintx.Logger.csproj" />
     <ProjectReference Include="..\libfintx.Sepa\libfintx.Sepa.csproj" />

--- a/src/libfintx.Sample/libfintx.Sample.csproj
+++ b/src/libfintx.Sample/libfintx.Sample.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\libfintx\libfintx.csproj" />
+    <ProjectReference Include="..\libfintx.FinTS\libfintx.FinTS.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR removes unused references. This is beneficial for better assembly loading performance. They can be added on demand if they are required in a later phase.