### PR TITLE
Security patch SixLabors.ImageSharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ There are many reasons why you need to use a banking library which can exchange 
 
 # Target platforms
 
-* .NET Standard 2.0
+* .NET Standard 2.0 (EBICS)
+* .NET 6.0+ (FinTS)
 
 # Sample
 
@@ -116,7 +117,7 @@ The verification process is done by using the default [**WebRequest**](https://m
 
 # Copyright & License
 
-Copyright (c) 2016 - 2023 **Torsten Klinger**
+Copyright (c) 2016 - 2024 **Torsten Klinger**
 
 Licensed under **GNU LESSER GENERAL PUBLIC LICENSE Version 3, 29 June 2007**. Please read the LICENSE file.
 

--- a/src/libfintx.EBICS/libfintx.EBICS.csproj
+++ b/src/libfintx.EBICS/libfintx.EBICS.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Iconic.Zlib.Netstandard" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.9" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libfintx.FinTS/libfintx.FinTS.csproj
+++ b/src/libfintx.FinTS/libfintx.FinTS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RootNamespace>libfintx.FinTS</RootNamespace>
     <Version>1.1.0</Version>
     <Authors>Torsten Klinger</Authors>
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0010" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libfintx.Sample.Ui/libfintx.Sample.Ui.csproj
+++ b/src/libfintx.Sample.Ui/libfintx.Sample.Ui.csproj
@@ -22,7 +22,7 @@
     <None Include="tan.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libfintx.FinTS\libfintx.FinTS.csproj">

--- a/src/libfintx.Xml/libfintx.Xml.csproj
+++ b/src/libfintx.Xml/libfintx.Xml.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a security patch. It uses the newest version of SixLabors.ImageSharp because of [this vulnerability](https://github.com/advisories/GHSA-65x7-c272-7g7r), severity **high**.

@torstenklement To be able to do this upgrade, I had to remove .NET Standard 2.0 support from the libfintx.FinTS package, because the newest version of package SixLabors.ImageSharp does not support .NET Standard anymore - only .NET 6.0+