### PR TITLE
remove message version overwrite based on HISPAS_AccountNationalAllowed

### DIFF
--- a/src/libfintx.FinTS/Segments/HKKAZ.cs
+++ b/src/libfintx.FinTS/Segments/HKKAZ.cs
@@ -63,7 +63,7 @@ namespace libfintx.FinTS
             {
                 if (string.IsNullOrEmpty(Startpoint))
                 {
-                    if (client.HIKAZS < 7 && client.HISPAS_AccountNationalAllowed)
+                    if (client.HIKAZS < 7)
                     {
                         StringBuilder sb = new StringBuilder();
                         sb.Append(activeAccount.AccountNumber);
@@ -107,7 +107,7 @@ namespace libfintx.FinTS
                 }
                 else
                 {
-                    if (client.HIKAZS < 7 && client.HISPAS_AccountNationalAllowed)
+                    if (client.HIKAZS < 7)
                     {
                         StringBuilder sb = new StringBuilder();
                         sb.Append(activeAccount.AccountNumber);
@@ -162,7 +162,7 @@ namespace libfintx.FinTS
             {
                 if (string.IsNullOrEmpty(Startpoint))
                 {
-                    if (client.HIKAZS < 7 && client.HISPAS_AccountNationalAllowed)
+                    if (client.HIKAZS < 7)
                     {
                         StringBuilder sb = new StringBuilder();
                         sb.Append(activeAccount.AccountNumber);
@@ -225,7 +225,7 @@ namespace libfintx.FinTS
                 }
                 else
                 {
-                    if (client.HIKAZS < 7 && client.HISPAS_AccountNationalAllowed)
+                    if (client.HIKAZS < 7)
                     {
                         StringBuilder sb = new StringBuilder();
                         sb.Append(activeAccount.AccountNumber);

--- a/src/libfintx.FinTS/Segments/HKSAL.cs
+++ b/src/libfintx.FinTS/Segments/HKSAL.cs
@@ -61,7 +61,7 @@ namespace libfintx.FinTS
 
             SEG sEG = new SEG();
 
-            if (client.HISALS >= 7 || !client.HISPAS_AccountNationalAllowed)
+            if (client.HISALS >= 7)
             {
                 StringBuilder sb = new StringBuilder();
                 sb.Append(activeAccount.AccountIban);


### PR DESCRIPTION
Since commit https://github.com/libfintx/libfintx/commit/5cc1824dbb461fb686fa67c825b0de7cf967ace5 it is not anymore possible to request transactions (Umsätze) from various bank:
* DKB - reported by @korneliuscode - I was able to confirm it
* Sparkasse - reported by Kristian Graul 

This pull request removes the added development to use another message version, when the BPN parameter "Nationale Kontoverbindung erlaubt" is set to false.

I tested this and it fixes the issue with the DKB bank.