### PR TITLE
make use of library SixLabors.ImageSharp optional

### DIFF
--- a/src/libfintx.FinTS/Helper/Helper_TAN.cs
+++ b/src/libfintx.FinTS/Helper/Helper_TAN.cs
@@ -101,7 +101,12 @@ namespace libfintx.FinTS
                 }
                 else
                 {
+#if USE_LIB_SixLabors_ImageSharp
                     tanDialog.FlickerImage = flickerCodeRenderer.RenderAsGif(tanDialog.FlickerWidth, tanDialog.FlickerHeight);
+#else
+                    throw new NotSupportedException($"{nameof(TANDialog)}.{nameof(TANDialog.RenderFlickerCodeAsGif)} is not supported.");
+#endif
+
                 }
             }
 
@@ -139,7 +144,11 @@ namespace libfintx.FinTS
                 }
                 else
                 {
+#if USE_LIB_SixLabors_ImageSharp
                     tanDialog.FlickerImage = flickerCodeRenderer.RenderAsGif(tanDialog.FlickerWidth, tanDialog.FlickerHeight);
+#else
+                    throw new NotSupportedException($"{nameof(TANDialog)}.{nameof(TANDialog.RenderFlickerCodeAsGif)} is not supported.");
+#endif
                 }
             }
 
@@ -150,7 +159,7 @@ namespace libfintx.FinTS
 
                 var mCode = new MatrixCode(PhotoCode.Substring(5, PhotoCode.Length - 5));
 
-                tanDialog.MatrixImage = mCode.CodeImage;
+                tanDialog.MatrixCode = mCode;
                 mCode.Render(tanDialog.PictureBox);
             }
 
@@ -165,7 +174,7 @@ namespace libfintx.FinTS
 
                     var mCode = new MatrixCode(PhotoBinary);
 
-                    tanDialog.MatrixImage = mCode.CodeImage;
+                    tanDialog.MatrixCode = mCode;
                     mCode.Render(tanDialog.PictureBox);
                 }
             }

--- a/src/libfintx.FinTS/TANDialog.cs
+++ b/src/libfintx.FinTS/TANDialog.cs
@@ -21,8 +21,10 @@
  * 	
  */
 
+#if USE_LIB_SixLabors_ImageSharp
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+#endif
 using System;
 using System.Threading.Tasks;
 
@@ -51,9 +53,13 @@ namespace libfintx.FinTS
 
         public HBCIDialogResult DialogResult { get; internal set; }
 
+#if USE_LIB_SixLabors_ImageSharp
         public Image<Rgba32> FlickerImage { get; internal set; }
 
-        public Image<Rgba32> MatrixImage { get; internal set; }
+        public Image<Rgba32> MatrixImage => MatrixCode.CodeImage;
+#endif
+
+        public MatrixCode MatrixCode { get; internal set; }
 
         /// <summary>
         /// Bei Verwendung des Decoupled-Verfahren (HKTAN#7) setzen.
@@ -77,13 +83,19 @@ namespace libfintx.FinTS
         /// </summary>
         /// <param name="waitForTanAsync"></param>
         /// <param name="dialogResult"></param>
-        /// <param name="flickerImage"></param>
         /// <param name="flickerWidth"></param>
         /// <param name="flickerHeight"></param>
+#if !USE_LIB_SixLabors_ImageSharp
+        [Obsolete("This constructor cannot be used, because the libfintx.FinTS library has been compiled without library support for SixLabors.ImageSharp.", true)]
+#endif
         public TANDialog(Func<TANDialog, Task<string>> waitForTanAsync, int flickerWidth = 320, int flickerHeight = 120)
             : this(waitForTanAsync)
         {
+#if USE_LIB_SixLabors_ImageSharp
             RenderFlickerCodeAsGif = true;
+#else
+            throw new NotSupportedException("This constructor cannot be used, because the libfintx.FinTS library has been compiled without library support for SixLabors.ImageSharp.");
+#endif
             FlickerWidth = flickerWidth;
             FlickerHeight = flickerHeight;
         }

--- a/src/libfintx.FinTS/Tan/FlickerRenderer.cs
+++ b/src/libfintx.FinTS/Tan/FlickerRenderer.cs
@@ -285,15 +285,16 @@ namespace libfintx.FinTS
     }
 }*/
 
-
+#if USE_LIB_SixLabors_ImageSharp
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Drawing.Processing;
+using CoreRectangle = SixLabors.ImageSharp.Rectangle;
+#endif
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using CoreRectangle = SixLabors.ImageSharp.Rectangle;
 
 namespace libfintx.FinTS
 {
@@ -370,6 +371,7 @@ namespace libfintx.FinTS
             }
         }
 
+#if USE_LIB_SixLabors_ImageSharp
         public Image<Rgba32> RenderAsGif(int width = 320, int height = 120)
         {
             using (var image = new Image<Rgba32>(width, height))
@@ -397,6 +399,7 @@ namespace libfintx.FinTS
                 return image;
             }
         }
+#endif
 
         /// <summary>
         /// Sets the clock frequency in Hz

--- a/src/libfintx.FinTS/libfintx.FinTS.csproj
+++ b/src/libfintx.FinTS/libfintx.FinTS.csproj
@@ -20,12 +20,19 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\libfintx.snk</AssemblyOriginatorKeyFile>
+
+    <!-- Optionally enable this option to use library SixLabors.ImageSharp for image rendering -->
+    <!--<DefineConstants>USE_LIB_SixLabors_ImageSharp</DefineConstants>-->
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.2" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="$(DefineConstants.Contains('USE_LIB_SixLabors_ImageSharp'))">
+      <ItemGroup>
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
+        <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.2" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <ItemGroup>
     <ProjectReference Include="..\libfintx.Globals\libfintx.Globals.csproj" />

--- a/src/libfintx.Sample.Ui/MainForm.cs
+++ b/src/libfintx.Sample.Ui/MainForm.cs
@@ -5,9 +5,9 @@ using libfintx.FinTSConfig;
 using libfintx.Globals;
 using libfintx.Sepa;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -615,11 +615,13 @@ namespace libfintx.Sample.Ui
                 return await Task.FromResult((string)null);
             }
 
-            if (tanDialog.MatrixImage != null)
+            if (tanDialog.MatrixCode != null)
             {
                 using (var memoryStream = new MemoryStream())
                 {
-                    tanDialog.MatrixImage.SaveAsBmp(memoryStream);
+                    var ms = new MemoryStream(tanDialog.MatrixCode.ImageData);
+                    var codeImage = (Image<Rgba32>) Image.Load(ms);
+                    codeImage.SaveAsBmp(memoryStream);
                     memoryStream.Seek(0, SeekOrigin.Begin);
                     pBox_tan.Image = new System.Drawing.Bitmap(memoryStream);
                 }

--- a/src/libfintx.Tests/Test.cs
+++ b/src/libfintx.Tests/Test.cs
@@ -38,7 +38,9 @@ using hbci = libfintx;
 using System.Windows.Forms;
 #endif
 
+#if USE_LIB_SixLabors_ImageSharp
 using SixLabors.ImageSharp;
+#endif
 
 namespace libfintx.Tests
 {
@@ -141,7 +143,12 @@ namespace libfintx.Tests
 
             var mCode = new MatrixCode(PhotoCode);
 
+            Assert.NotNull(mCode.ImageMimeType);
+            Assert.NotNull(mCode.ImageData);
+
+#if USE_LIB_SixLabors_ImageSharp
             mCode.CodeImage.SaveAsPng(File.OpenWrite(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "matrixcode.png")));
+#endif
         }
 
         [Fact(Skip = "You have to provide the connection details for this test")]

--- a/src/libfintx.Tests/libfintx.Tests.csproj
+++ b/src/libfintx.Tests/libfintx.Tests.csproj
@@ -5,6 +5,9 @@
     <IsPackable>false</IsPackable>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\libfintx.snk</AssemblyOriginatorKeyFile>
+
+    <!-- Optionally enable this option to use library SixLabors.ImageSharp for image rendering -->
+    <!--<DefineConstants>USE_LIB_SixLabors_ImageSharp</DefineConstants>-->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Introduce a new compilation option `USE_LIB_SixLabors_ImageSharp` which can be used to compile libfintx.FinTS with SixLabors.ImageSharp dependency - but by default, it will not include the SixLabors.ImageSharp library as dependency anymore.

Note: This code is clean for MatrixCode implementation. I was not able to verify if this will still work with the FlickerCode TAN option.