### PR TITLE
Fix decoupled TAN (HKTAN#7) not completing when bank sends both 0030 and 3955

### DIFF
--- a/src/libfintx.FinTS/Data/UPD/UPD.cs
+++ b/src/libfintx.FinTS/Data/UPD/UPD.cs
@@ -57,107 +57,120 @@ namespace libfintx.FinTS
             AccountList = new List<AccountInformation>();
             try
             {
-                var segments = Helper.SplitSegments(message);
+                var segments = Helper.SplitSegments((message ?? string.Empty).TrimStart('\'', '\r', '\n', ' '));
 
                 foreach (string segment in segments)
                 {
                     if (!segment.StartsWith("HIUPD"))
+                    {
                         continue;
+                    }
 
-                    string Accountnumber = null;
-                    string SubAccountFeature = null;
-                    string Accountbankcode = null;
-                    string Accountiban = null;
-                    string Accountuserid = null;
-                    string Accounttype = null;
-                    string Accountcurrency = null;
-                    string Accountowner = null;
-                    List<AccountPermission> Accountpermissions = new List<AccountPermission>();
-
-                    // HIUPD:165:6:4+0123456789::280:10050000+DE22100500000123456789+5985932562+10+EUR+Meier+Peter+Sparkassenbuch Gold
-                    var match = Regex.Match(segment, @"HIUPD.*?\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+");
-                    if (match.Success)
+                    try
                     {
-                        var accountInfo = match.Groups[1].Value;
-                        var matchInfo = Regex.Match(accountInfo, @"(\d+):(.*?):280:(\d+)");
-                        if (matchInfo.Success)
+                        string Accountnumber = null;
+                        string SubAccountFeature = null;
+                        string Accountbankcode = null;
+                        string Accountiban = null;
+                        string Accountuserid = null;
+                        string Accounttype = null;
+                        string Accountcurrency = null;
+                        string Accountowner = null;
+                        List<AccountPermission> Accountpermissions = new List<AccountPermission>();
+
+                        // HIUPD:165:6:4+0123456789::280:10050000+DE22100500000123456789+5985932562+10+EUR+Meier+Peter+Sparkassenbuch Gold
+                        var match = Regex.Match(segment, @"HIUPD.*?\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+(.*?)\+");
+                        if (match.Success)
                         {
-                            Accountnumber = matchInfo.Groups[1].Value;
-                            SubAccountFeature = matchInfo.Groups[2].Value;
-                            Accountbankcode = matchInfo.Groups[3].Value;
-                        }
-
-                        Accountiban = match.Groups[2].Value;
-                        Accountuserid = match.Groups[3].Value;
-                        Accounttype = match.Groups[4].Value;
-                        Accountcurrency = match.Groups[5].Value;
-                        Accountowner = $"{match.Groups[6]} {match.Groups[7]}";
-                        Accounttype = match.Groups[8].Value;
-
-                        if (Accountnumber?.Length > 2 || Accountiban?.Length > 2)
-                        {
-                            // Account permissions
-                            string pat = @"\+[A-Z]+:1";
-                            var res = Regex.Matches(segment, pat, RegexOptions.Singleline);
-
-                            for (int c = 0; c <= res.Count - 1; c++)
+                            var accountInfo = match.Groups[1].Value;
+                            var matchInfo = Regex.Match(accountInfo, @"(\d+):(.*?):280:(\d+)");
+                            if (matchInfo.Success)
                             {
-                                if (res[c].Value.Length < 10)
+                                Accountnumber = matchInfo.Groups[1].Value;
+                                SubAccountFeature = matchInfo.Groups[2].Value;
+                                Accountbankcode = matchInfo.Groups[3].Value;
+                            }
+
+                            Accountiban = match.Groups[2].Value;
+                            Accountuserid = match.Groups[3].Value;
+                            Accounttype = match.Groups[4].Value;
+                            Accountcurrency = match.Groups[5].Value;
+                            Accountowner = $"{match.Groups[6]} {match.Groups[7]}";
+                            Accounttype = match.Groups[8].Value;
+
+                            if (Accountnumber?.Length > 2 || Accountiban?.Length > 2)
+                            {
+                                // Account permissions
+                                string pat = @"\+[A-Z]+:1";
+                                var res = Regex.Matches(segment, pat, RegexOptions.Singleline);
+
+                                for (int c = 0; c <= res.Count - 1; c++)
                                 {
-                                    Accountpermissions.Add(new AccountPermission
+                                    if (res[c].Value.Length < 10)
                                     {
-                                        Segment = res[c].Value.Replace("+", "").Replace(":1", ""),
-                                        Description = AccountPermission.Permission(res[c].Value.Replace("+", "").Replace(":1", ""))
-                                    });
+                                        Accountpermissions.Add(new AccountPermission
+                                        {
+                                            Segment = res[c].Value.Replace("+", "").Replace(":1", ""),
+                                            Description = AccountPermission.Permission(res[c].Value.Replace("+", "").Replace(":1", ""))
+                                        });
+                                    }
                                 }
                             }
                         }
-                    }
-                    else // Fallback
-                    {
-                        Accountiban = "DE" + Helper.Parse_String(segment, "+DE", "+");
-                        Accountowner = Helper.Parse_String(segment, "EUR+", "+");
-                        Accounttype = Helper.Parse_String(segment.Replace("++EUR+", ""), "++", "++");
-
-                        if (Accountnumber?.Length > 2 || Accountiban?.Length > 2)
+                        else // Fallback
                         {
-                            // Account permissions
-                            string pat = "\\+.*?:1";
-                            MatchCollection res = Regex.Matches(segment, pat, RegexOptions.Singleline);
+                            Accountiban = "DE" + Helper.Parse_String(segment, "+DE", "+");
+                            Accountowner = Helper.Parse_String(segment, "EUR+", "+");
+                            Accounttype = Helper.Parse_String(segment.Replace("++EUR+", ""), "++", "++");
 
-                            for (int c = 0; c <= res.Count - 1; c++)
+                            if (Accountnumber?.Length > 2 || Accountiban?.Length > 2)
                             {
-                                if (res[c].Value.Length < 10)
+                                // Account permissions
+                                string pat = "\\+.*?:1";
+                                MatchCollection res = Regex.Matches(segment, pat, RegexOptions.Singleline);
+
+                                for (int c = 0; c <= res.Count - 1; c++)
                                 {
-                                    Accountpermissions.Add(new AccountPermission
+                                    if (res[c].Value.Length < 10)
                                     {
-                                        Segment = res[c].Value.Replace("+", "").Replace(":1", ""),
-                                        Description = AccountPermission.Permission(res[c].Value.Replace("+", "").Replace(":1", ""))
-                                    });
+                                        Accountpermissions.Add(new AccountPermission
+                                        {
+                                            Segment = res[c].Value.Replace("+", "").Replace(":1", ""),
+                                            Description = AccountPermission.Permission(res[c].Value.Replace("+", "").Replace(":1", ""))
+                                        });
+                                    }
                                 }
                             }
                         }
-                    }
 
-                    if (Accountnumber?.Length > 2 || Accountiban?.Length > 2)
-                        AccountList.Add(new AccountInformation()
+                        if (Accountnumber?.Length > 2 || Accountiban?.Length > 2)
                         {
-                            AccountNumber = Accountnumber,
-                            SubAccountFeature = SubAccountFeature,
-                            AccountBankCode = Accountbankcode,
-                            AccountIban = Accountiban,
-                            AccountUserId = Accountuserid,
-                            AccountType = Accounttype,
-                            AccountCurrency = Accountcurrency,
-                            AccountOwner = Accountowner,
-                            AccountPermissions = Accountpermissions
-                        }); ;
+                            AccountList.Add(new AccountInformation
+                            {
+                                AccountNumber = Accountnumber,
+                                SubAccountFeature = SubAccountFeature,
+                                AccountBankCode = Accountbankcode,
+                                AccountIban = Accountiban,
+                                AccountUserId = Accountuserid,
+                                AccountType = Accounttype,
+                                AccountCurrency = Accountcurrency,
+                                AccountOwner = Accountowner,
+                                AccountPermissions = Accountpermissions
+                            });
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogWarning("Unable to parse HIUPD segment. Segment ignored. {Message}", ex.Message);
+                    }
                 }
 
                 if (AccountList.Count > 0)
+                {
                     return true;
-                else
-                    return false;
+                }
+
+                return false;
             }
             catch (Exception ex)
             {

--- a/src/libfintx.FinTS/FinTsClient.cs
+++ b/src/libfintx.FinTS/FinTsClient.cs
@@ -390,7 +390,7 @@ namespace libfintx.FinTS
             }
 
             tanDialog.DialogResult = result;
-            if (result.IsTanRequired)
+            if (result.IsTanRequired && !result.IsApprovalRequired)
             {
                 string tan = await Helper.WaitForTanAsync(this, result, tanDialog);
                 if (tan == null)

--- a/src/libfintx.FinTS/FinTsClientMessageParsing.cs
+++ b/src/libfintx.FinTS/FinTsClientMessageParsing.cs
@@ -261,6 +261,39 @@ public partial class FinTsClient
             if (this.HIKAZS == 0)
                 this.HIKAZS = 0;
 
+            // If HITANS wasn't set from the response (e.g. bank skipped BPD because version is unchanged),
+            // fall back to the cached BPD file so that HKTAN is included in the next INI message.
+            if (this.HITANS == 0)
+            {
+                var cachedBpd = this.BPD;
+                if (cachedBpd?.HITANS?.Count > 0)
+                {
+                    if (!string.IsNullOrEmpty(this.HIRMS) && int.TryParse(this.HIRMS, out int hirmsCode))
+                    {
+                        foreach (var hitansEntry in cachedBpd.HITANS)
+                        {
+                            if (hitansEntry.TanProcesses.Any(tp => tp.TanCode == hirmsCode))
+                            {
+                                this.HITANS = hitansEntry.Version;
+                                break;
+                            }
+                        }
+                    }
+                    else if (!string.IsNullOrEmpty(this.HIRMSf))
+                    {
+                        var tanCodes = this.HIRMSf.Split(';').Where(s => int.TryParse(s, out _)).Select(s => Convert.ToInt32(s)).ToList();
+                        foreach (var hitansEntry in cachedBpd.HITANS)
+                        {
+                            if (hitansEntry.TanProcesses.Select(tp => tp.TanCode).Intersect(tanCodes).Any())
+                            {
+                                this.HITANS = hitansEntry.Version;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
             return result;
         }
         catch (Exception ex)

--- a/src/libfintx.FinTS/Helper/Helper_Segment.cs
+++ b/src/libfintx.FinTS/Helper/Helper_Segment.cs
@@ -136,6 +136,13 @@ namespace libfintx.FinTS
         /// <returns></returns>
         internal static IEnumerable<string> SplitSegments(string message)
         {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+
+            message = message.TrimStart('\'', '\r', '\n', ' ');
+            if (message.Length == 0)
+                yield break;
+
             StringBuilder currentSegment = new StringBuilder();
             message = ProcessSegmentBegin(message, currentSegment);
 
@@ -188,6 +195,7 @@ namespace libfintx.FinTS
                             currentSegment = new StringBuilder();
 
                             message = message.Substring(match.Index + match.Value.Length);
+                            message = message.TrimStart('\'', '\r', '\n', ' ');
                             if (message.Length > 0)
                                 message = ProcessSegmentBegin(message, currentSegment);
 

--- a/src/libfintx.FinTS/Segments/HKKAZ.cs
+++ b/src/libfintx.FinTS/Segments/HKKAZ.cs
@@ -22,6 +22,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using libfintx.FinTS.Data;
@@ -41,21 +43,8 @@ namespace libfintx.FinTS
             client.Logger.LogInformation("Starting job HKKAZ: Request transactions");
 
             SEG sEG = new SEG();
-
-            var connectionDetails = client.ConnectionDetails;
             string segments = string.Empty;
-            AccountInformation activeAccount;
-            if (client.activeAccount != null)
-                activeAccount = client.activeAccount;
-            else
-                activeAccount = new AccountInformation()
-                {
-                    AccountNumber = connectionDetails.Account,
-                    AccountBankCode = connectionDetails.Blz.ToString(),
-                    SubAccountFeature = connectionDetails.SubAccount,
-                    AccountIban = connectionDetails.Iban,
-                    AccountBic = connectionDetails.Bic,
-                };
+            var activeAccount = ResolveAccountForHkkaz(client);
 
             client.SEGNUM = Convert.ToInt16(SEG_NUM.Seg3);
 
@@ -294,6 +283,263 @@ namespace libfintx.FinTS
             client.Parse_Message(response);
 
             return response;
+        }
+
+        private static AccountInformation ResolveAccountForHkkaz(FinTsClient client)
+        {
+            if (client.activeAccount != null)
+            {
+                client.Logger.LogInformation(
+                    "Kontozuordnung (HKKAZ): bereits gesetztes aktives Konto wird verwendet. IBAN={Iban}, Konto={Account}, Unterkonto={SubAccount}, BLZ={Blz}",
+                    MaskValue(client.activeAccount.AccountIban),
+                    MaskValue(client.activeAccount.AccountNumber),
+                    MaskValue(client.activeAccount.SubAccountFeature),
+                    MaskValue(client.activeAccount.AccountBankCode));
+                return client.activeAccount;
+            }
+
+            var fallbackAccount = CreateAccountFromConnection(client.ConnectionDetails);
+            var candidates = UPD.AccountList ?? new List<AccountInformation>();
+            if (candidates.Count == 0)
+            {
+                client.Logger.LogInformation(
+                    "Kontozuordnung (HKKAZ): keine UPD-Konten vorhanden, konfiguriertes Konto wird verwendet. IBAN={Iban}, Konto={Account}, Unterkonto={SubAccount}, BLZ={Blz}",
+                    MaskValue(fallbackAccount.AccountIban),
+                    MaskValue(fallbackAccount.AccountNumber),
+                    MaskValue(fallbackAccount.SubAccountFeature),
+                    MaskValue(fallbackAccount.AccountBankCode));
+                return fallbackAccount;
+            }
+
+            var connection = client.ConnectionDetails;
+            var bestIdentityScore = int.MinValue;
+            var scored = new List<(AccountInformation Account, int IdentityScore, int PreferenceScore)>();
+            foreach (var candidate in candidates)
+            {
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                var identityScore = CalculateIdentityScore(candidate, connection);
+                var preferenceScore = CalculatePreferenceScore(candidate);
+                scored.Add((candidate, identityScore, preferenceScore));
+                if (identityScore > bestIdentityScore)
+                {
+                    bestIdentityScore = identityScore;
+                }
+            }
+
+            if (bestIdentityScore <= 0)
+            {
+                client.Logger.LogInformation(
+                    "Kontozuordnung (HKKAZ): kein passendes UPD-Konto gefunden, konfiguriertes Konto wird verwendet. IBAN={Iban}, Konto={Account}, Unterkonto={SubAccount}, BLZ={Blz}",
+                    MaskValue(fallbackAccount.AccountIban),
+                    MaskValue(fallbackAccount.AccountNumber),
+                    MaskValue(fallbackAccount.SubAccountFeature),
+                    MaskValue(fallbackAccount.AccountBankCode));
+                return fallbackAccount;
+            }
+
+            var topByIdentity = scored
+                .Where(c => c.IdentityScore == bestIdentityScore)
+                .ToList();
+
+            var bestPreference = topByIdentity.Max(c => c.PreferenceScore);
+            var topCandidates = topByIdentity
+                .Where(c => c.PreferenceScore == bestPreference)
+                .Select(c => c.Account)
+                .ToList();
+
+            if (topCandidates.Count == 1)
+            {
+                var selected = topCandidates[0];
+                client.Logger.LogInformation(
+                    "Kontozuordnung (HKKAZ): UPD-Konto ausgewählt. IBAN={Iban}, Konto={Account}, Unterkonto={SubAccount}, BLZ={Blz}, HKKAZ={HasHkkaz}",
+                    MaskValue(selected.AccountIban),
+                    MaskValue(selected.AccountNumber),
+                    MaskValue(selected.SubAccountFeature),
+                    MaskValue(selected.AccountBankCode),
+                    HasSegmentPermission(selected, "HKKAZ") ? "ja" : "nein");
+                return selected;
+            }
+
+            client.Logger.LogWarning(
+                "Mehrdeutige Kontozuordnung (HKKAZ, {Count} Treffer). Es wird auf das konfigurierte Konto zurückgefallen.",
+                topCandidates.Count);
+
+            for (int i = 0; i < topCandidates.Count; i++)
+            {
+                var candidate = topCandidates[i];
+                client.Logger.LogInformation(
+                    "Kandidat {Index}: IBAN={Iban}, Konto={Account}, Unterkonto={SubAccount}, BLZ={Blz}, HKKAZ={HasHkkaz}",
+                    i + 1,
+                    MaskValue(candidate.AccountIban),
+                    MaskValue(candidate.AccountNumber),
+                    MaskValue(candidate.SubAccountFeature),
+                    MaskValue(candidate.AccountBankCode),
+                    HasSegmentPermission(candidate, "HKKAZ") ? "ja" : "nein");
+            }
+
+            client.Logger.LogInformation(
+                "Kontozuordnung (HKKAZ): konfiguriertes Konto wird verwendet. IBAN={Iban}, Konto={Account}, Unterkonto={SubAccount}, BLZ={Blz}",
+                MaskValue(fallbackAccount.AccountIban),
+                MaskValue(fallbackAccount.AccountNumber),
+                MaskValue(fallbackAccount.SubAccountFeature),
+                MaskValue(fallbackAccount.AccountBankCode));
+            return fallbackAccount;
+        }
+
+        private static AccountInformation CreateAccountFromConnection(ConnectionDetails connectionDetails)
+        {
+            return new AccountInformation
+            {
+                AccountNumber = connectionDetails.Account,
+                AccountBankCode = connectionDetails.Blz.ToString(),
+                SubAccountFeature = connectionDetails.SubAccount,
+                AccountIban = connectionDetails.Iban,
+                AccountBic = connectionDetails.Bic,
+            };
+        }
+
+        private static int CalculateIdentityScore(AccountInformation account, ConnectionDetails connection)
+        {
+            var score = 0;
+
+            var accountIban = NormalizeIban(account.AccountIban);
+            var configuredIban = NormalizeIban(connection.Iban);
+            if (!string.IsNullOrEmpty(accountIban) && !string.IsNullOrEmpty(configuredIban) && accountIban == configuredIban)
+            {
+                score += 1000;
+            }
+
+            var accountBlz = NormalizeDigits(account.AccountBankCode);
+            var configuredBlz = NormalizeDigits(connection.Blz.ToString());
+            var accountNumber = NormalizeAccountNumber(account.AccountNumber);
+            var configuredAccount = NormalizeAccountNumber(connection.Account);
+
+            var exactAccount = !string.IsNullOrEmpty(account.AccountNumber)
+                               && !string.IsNullOrEmpty(connection.Account)
+                               && string.Equals(account.AccountNumber, connection.Account, StringComparison.Ordinal);
+            var normalizedAccount = !string.IsNullOrEmpty(accountNumber)
+                                    && !string.IsNullOrEmpty(configuredAccount)
+                                    && string.Equals(accountNumber, configuredAccount, StringComparison.Ordinal);
+            var blzMatches = !string.IsNullOrEmpty(accountBlz)
+                             && !string.IsNullOrEmpty(configuredBlz)
+                             && string.Equals(accountBlz, configuredBlz, StringComparison.Ordinal);
+
+            if (exactAccount && blzMatches)
+            {
+                score += 900;
+            }
+            else if (normalizedAccount && blzMatches)
+            {
+                score += 800;
+            }
+            else if (exactAccount)
+            {
+                score += 400;
+            }
+            else if (normalizedAccount)
+            {
+                score += 300;
+            }
+
+            if (blzMatches)
+            {
+                score += 100;
+            }
+
+            if (!string.IsNullOrWhiteSpace(connection.SubAccount)
+                && !string.IsNullOrWhiteSpace(account.SubAccountFeature)
+                && string.Equals(account.SubAccountFeature.Trim(), connection.SubAccount.Trim(), StringComparison.Ordinal))
+            {
+                score += 50;
+            }
+
+            return score;
+        }
+
+        private static int CalculatePreferenceScore(AccountInformation account)
+        {
+            var score = 0;
+
+            if (HasSegmentPermission(account, "HKKAZ"))
+            {
+                score += 10;
+            }
+
+            if (!string.IsNullOrWhiteSpace(account.AccountIban))
+            {
+                score += 2;
+            }
+
+            if (!string.IsNullOrWhiteSpace(account.AccountNumber))
+            {
+                score += 1;
+            }
+
+            return score;
+        }
+
+        private static bool HasSegmentPermission(AccountInformation account, string segment)
+        {
+            return account?.AccountPermissions?.Any(p => string.Equals(p.Segment, segment, StringComparison.OrdinalIgnoreCase)) == true;
+        }
+
+        private static string NormalizeIban(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            return new string(value.Where(c => !char.IsWhiteSpace(c)).ToArray()).ToUpperInvariant();
+        }
+
+        private static string NormalizeDigits(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            return new string(value.Where(char.IsDigit).ToArray());
+        }
+
+        private static string NormalizeAccountNumber(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var trimmed = value.Trim();
+            if (trimmed.All(char.IsDigit))
+            {
+                var withoutLeadingZeros = trimmed.TrimStart('0');
+                return withoutLeadingZeros.Length == 0 ? "0" : withoutLeadingZeros;
+            }
+
+            return trimmed.ToUpperInvariant();
+        }
+
+        private static string MaskValue(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return "(leer)";
+            }
+
+            var normalized = value.Trim();
+            if (normalized.Length <= 8)
+            {
+                return new string('*', normalized.Length);
+            }
+
+            return normalized.Substring(0, 4)
+                   + new string('*', normalized.Length - 8)
+                   + normalized.Substring(normalized.Length - 4);
         }
     }
 }


### PR DESCRIPTION
## Summary

  - `ProcessSCA` checked `IsTanRequired` (code `0030`) before `IsApprovalRequired`
    (code `3955`) in an if/else chain
  - Some banks send **both** codes together in the INI response for decoupled/push TAN:
    `0030` as a general acknowledgment and `3955` to signal out-of-band approval is required
  - Because `IsTanRequired` won the branch, `WaitForTanAsync` was called expecting the user
    to type a TAN; when none was returned the authentication was silently skipped, and
    subsequent requests (e.g. HKKAZ) failed with `9800` (Dialog abgebrochen)

  **Fix:** change the condition to `IsTanRequired && !IsApprovalRequired`. When `3955` is
  present — with or without `0030` — the decoupled polling loop now always runs.

  ## Test plan

  - [ ] Decoupled/push TAN flow (HKTAN#7): bank sends `0030` + `3955` → polling loop
        executes, user approves in app, subsequent HKKAZ succeeds
  - [ ] Standard TAN flow (bank sends only `0030`, no `3955`): behaviour unchanged,
        `WaitForTanAsync` is called as before
  - [ ] Pure decoupled response (bank sends only `3955`, no `0030`): behaviour unchanged,
        polling loop runs as before

 ## Changes

  ### 1. Fix decoupled TAN (HKTAN#7) not completing (commit 918190a)
  When a bank sends both return code `0030` and `3955` in the same
  response, `IsTanRequired` was winning the `if/else` over
  `IsApprovalRequired`, preventing the decoupled polling loop from
  ever running. Fixed by checking `IsTanRequired && !IsApprovalRequired`.

  ### 2. Fix HKTAN omitted when bank skips BPD due to cached version (commit f7ed2f4)
  When the locally cached BPD version matches what the bank has, the
  bank omits HITANS from the sync response. This left `client.HITANS`
  at 0, causing `Init_INI` to skip HKTAN in the next message. Banks
  that require SCA on every dialog (e.g. comdirect photoTAN) reject
  the request with `9075 SCA required` / `9340 Invalid Signature`.

  After parsing the response, if HITANS is still 0, the fix falls back
  to the cached BPD file and resolves the HITANS version from there.

 ### 3. Added deterministic HKKAZ account resolution based on IBAN/account/BLZ matching with leading-zero normalization.
Added clear masked logging for selected/ambiguous candidates.
Kept pseudo accounts in UPD (no filtering).
Hardened UPD parsing and segment splitting against malformed/extra delimiters.

Root cause: account selection for transaction request could be ambiguous with mixed UPD entries (including pseudo IBAN entries), causing invalid account payload (9210) in HKKAZ.
Fix:

Result: no pseudo-account filtering, better diagnostics, and stable account selection for transaction downloads.

  ## Affected banks
  - Fix 1: DKB (and any bank using HKTAN#7 decoupled / push TAN)
  - Fix 2: comdirect photoTAN (and any bank requiring SCA with cached BPD)


