### PR TITLE
fix LetterDE<T> hash

### DIFF
--- a/src/libfintx.EBICS/Letters/Letter.cs
+++ b/src/libfintx.EBICS/Letters/Letter.cs
@@ -50,10 +50,7 @@ namespace libfintx.EBICS.Letters
         }
         static byte[] CalcHash(byte[] modulus, byte[] exponent)
         {
-            var txt = BitConverter.ToString(exponent).TrimStart('0').Replace("-", "").ToLower() +
-                BitConverter.ToString(modulus).TrimStart('0').Replace("-", "").ToLower();
-            var cert = System.Text.Encoding.UTF8.GetBytes(txt);
-            return System.Security.Cryptography.SHA256.Create().ComputeHash(cert);
+            return libfintx.EBICSConfig.KeyDigest.ComputeGermanHash(modulus, exponent);
         }
         public void Build(byte[] certificate,byte [] modulus, byte [] exponent)
         {

--- a/src/libfintx.EBICSConfig/KeyPair.cs
+++ b/src/libfintx.EBICSConfig/KeyPair.cs
@@ -114,16 +114,7 @@ namespace libfintx.EBICSConfig
                 }
 
                 var p = _publicKey.ExportParameters(false);
-                var hexExp = BitConverter.ToString(p.Exponent).Replace("-", string.Empty).ToLower()
-                    .TrimStart('0');
-                var hexMod = BitConverter.ToString(p.Modulus).Replace("-", string.Empty).ToLower()
-                    .TrimStart('0');
-                var hashInput = Encoding.ASCII.GetBytes(string.Format("{0} {1}", hexExp, hexMod));
-
-                using (var sha256 = SHA256.Create())
-                {
-                    return sha256.ComputeHash(hashInput);
-                }
+                return KeyDigest.ComputeGermanHash(p.Modulus, p.Exponent);
             }
         }
 
@@ -227,5 +218,24 @@ namespace libfintx.EBICSConfig
         }
 
         public override string ToString() => _printer.PrintObject(this);
+    }
+
+    /// <summary>
+    /// Computes the EBICS public key digest: SHA-256 of ASCII(hex(exponent) + " " + hex(modulus)),
+    /// with leading zeros stripped from each hex string.
+    /// This is the hash shown in German INI/HIA letters and verified by the bank.
+    /// </summary>
+    public static class KeyDigest
+    {
+        public static byte[] ComputeGermanHash(byte[] modulus, byte[] exponent)
+        {
+            var hexExp = BitConverter.ToString(exponent).Replace("-", string.Empty).ToLower().TrimStart('0');
+            var hexMod = BitConverter.ToString(modulus).Replace("-", string.Empty).ToLower().TrimStart('0');
+            var hashInput = Encoding.ASCII.GetBytes(string.Format("{0} {1}", hexExp, hexMod));
+            using (var sha256 = SHA256.Create())
+            {
+                return sha256.ComputeHash(hashInput);
+            }
+        }
     }
 }


### PR DESCRIPTION
I had problems trying using LetterDE<T>, the hash calculation used there doesn't match the one used electronically in KeyPair<T>. 

LetterDE just concatenates exponent and modulus parts, while KeyPair uses `string.Format("{0} {1}", hexExp, hexMod)` (space in between). 

I have extracted a method from `KeyPair<T>` to a `KeyDigest` utility class,  so that the LetterDE<T> can also use it. 