### PR TITLE
C53

### DIFF
--- a/src/libfintx.EBICS/Commands/C53Command.cs
+++ b/src/libfintx.EBICS/Commands/C53Command.cs
@@ -79,12 +79,12 @@ namespace libfintx.EBICS.Commands
                             _initLastSegment = dr.LastSegment;
                             _orderData = new string[_numSegments];
                             _orderData[dr.SegmentNumber - 1] =
-                                Encoding.UTF8.GetString(Decompress(DecryptOrderData(xph)));
+                                Encoding.Latin1.GetString(Decompress(DecryptOrderData(xph)));
                             Response.Data = string.Join("", _orderData);
                             break;
                         case TransactionPhase.Transfer:
                             _orderData[dr.SegmentNumber - 1] =
-                                Encoding.UTF8.GetString(Decompress(DecryptOrderData(xph)));
+                                Encoding.Latin1.GetString(Decompress(DecryptOrderData(xph)));
                             // Zip File ausgeben
                             Guid myuuid = Guid.NewGuid();
                             string myuuidAsString = myuuid.ToString();

--- a/src/libfintx.EBICS/EbicsClient.cs
+++ b/src/libfintx.EBICS/EbicsClient.cs
@@ -123,6 +123,15 @@ namespace libfintx.EBICS
             }
         }
 
+        public C53Response C53(C53Params p)
+        {
+            using (new MethodLogger(Logger))
+            {
+                var resp = _commandHandler.Send<C53Response>(p);
+                return resp;
+            }
+        }
+
         public CctResponse CCT(CctParams p)
         {
             using (new MethodLogger(Logger))

--- a/src/libfintx.EBICS/IEbicsClient.cs
+++ b/src/libfintx.EBICS/IEbicsClient.cs
@@ -32,6 +32,7 @@ namespace libfintx.EBICS
         HpbResponse HPB(HpbParams p);
         PtkResponse PTK(PtkParams p);
         StaResponse STA(StaParams p);
+        C53Response C53(C53Params p);
         CctResponse CCT(CctParams p);
         IniResponse INI(IniParams p);
         HiaResponse HIA(HiaParams p);

--- a/src/libfintx.EBICS/Letters/Letter.cs
+++ b/src/libfintx.EBICS/Letters/Letter.cs
@@ -50,10 +50,7 @@ namespace libfintx.EBICS.Letters
         }
         static byte[] CalcHash(byte[] modulus, byte[] exponent)
         {
-            var txt = BitConverter.ToString(exponent).TrimStart('0').Replace("-", "").ToLower() +
-                BitConverter.ToString(modulus).TrimStart('0').Replace("-", "").ToLower();
-            var cert = System.Text.Encoding.UTF8.GetBytes(txt);
-            return System.Security.Cryptography.SHA256.Create().ComputeHash(cert);
+            return libfintx.EBICSConfig.KeyDigest.ComputeGermanHash(modulus, exponent);
         }
         public void Build(byte[] certificate,byte [] modulus, byte [] exponent)
         {

--- a/src/libfintx.EBICS/libfintx.EBICS.csproj
+++ b/src/libfintx.EBICS/libfintx.EBICS.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iconic.Zlib.Netstandard" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
 

--- a/src/libfintx.EBICSConfig/KeyPair.cs
+++ b/src/libfintx.EBICSConfig/KeyPair.cs
@@ -114,16 +114,7 @@ namespace libfintx.EBICSConfig
                 }
 
                 var p = _publicKey.ExportParameters(false);
-                var hexExp = BitConverter.ToString(p.Exponent).Replace("-", string.Empty).ToLower()
-                    .TrimStart('0');
-                var hexMod = BitConverter.ToString(p.Modulus).Replace("-", string.Empty).ToLower()
-                    .TrimStart('0');
-                var hashInput = Encoding.ASCII.GetBytes(string.Format("{0} {1}", hexExp, hexMod));
-
-                using (var sha256 = SHA256.Create())
-                {
-                    return sha256.ComputeHash(hashInput);
-                }
+                return KeyDigest.ComputeGermanHash(p.Modulus, p.Exponent);
             }
         }
 
@@ -227,5 +218,24 @@ namespace libfintx.EBICSConfig
         }
 
         public override string ToString() => _printer.PrintObject(this);
+    }
+
+    /// <summary>
+    /// Computes the EBICS public key digest: SHA-256 of ASCII(hex(exponent) + " " + hex(modulus)),
+    /// with leading zeros stripped from each hex string.
+    /// This is the hash shown in German INI/HIA letters and verified by the bank.
+    /// </summary>
+    public static class KeyDigest
+    {
+        public static byte[] ComputeGermanHash(byte[] modulus, byte[] exponent)
+        {
+            var hexExp = BitConverter.ToString(exponent).Replace("-", string.Empty).ToLower().TrimStart('0');
+            var hexMod = BitConverter.ToString(modulus).Replace("-", string.Empty).ToLower().TrimStart('0');
+            var hashInput = Encoding.ASCII.GetBytes(string.Format("{0} {1}", hexExp, hexMod));
+            using (var sha256 = SHA256.Create())
+            {
+                return sha256.ComputeHash(hashInput);
+            }
+        }
     }
 }

--- a/src/libfintx.EBICSConfig/libfintx.EBICSConfig.csproj
+++ b/src/libfintx.EBICSConfig/libfintx.EBICSConfig.csproj
@@ -11,7 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
 

--- a/src/libfintx.Xml/libfintx.Xml.csproj
+++ b/src/libfintx.Xml/libfintx.Xml.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libfintx.Xsd/libfintx.Xsd.csproj
+++ b/src/libfintx.Xsd/libfintx.Xsd.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
A few changes to complete the C53 implementation: 

* add it to IEbicsClient / EbicsClient
* use Latin1 instead of UTF8 since is reversible, important for reading the ZIP file. 

I use it like this: 
```CS
  var response = client.C53(new C53Params
  {
      StartDate = startDate.ToDateTime(TimeOnly.MinValue),
      EndDate   = endDate.ToDateTime(TimeOnly.MinValue),
  });

  if (response.Data == null)
      throw new InvalidOperationException($"C53 returned no data for {startDate}–{endDate}.");

  var auftraggeberDic = Database.Query<TransactionAuftraggeberEntity>().ToDictionary(a => a.Konto);

  // C53Command decodes the EBICS order data with Latin1 (byte-preserving). The bank
  // wraps the CAMT.053 XML in a ZIP file, so we convert back to bytes via Latin1 and
  // open it as a ZipArchive. A date-range request may return multiple XML files (one
  // per day), so we parse each entry independently.
  IEnumerable<XDocument> docs;
  if (response.Data.StartsWith("PK"))
  {
      var zipBytes = Encoding.Latin1.GetBytes(response.Data);
      using var zip = new System.IO.Compression.ZipArchive(
          new System.IO.MemoryStream(zipBytes),
          System.IO.Compression.ZipArchiveMode.Read);
      docs = zip.Entries
          .Where(e => e.Name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
          .OrderBy(e => e.Name)
          .Select(e => new System.IO.StreamReader(e.Open(), Encoding.UTF8).Using(r => XDocument.Parse(r.ReadToEnd())))
          .ToList(); // materialise before zip is disposed
  }
  else
  {
      docs = [XDocument.Parse(response.Data)];
  }
```

After that I parse the file using LINQ to XML. 