### PR TITLE
Add net10.0 target framework to all library projects

### DIFF
--- a/src/libfintx.EBICS/libfintx.EBICS.csproj
+++ b/src/libfintx.EBICS/libfintx.EBICS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.EBICS</RootNamespace>
     <Description>C# based client library for EBICS H004 and EBICS H005.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.EBICSConfig/libfintx.EBICSConfig.csproj
+++ b/src/libfintx.EBICSConfig/libfintx.EBICSConfig.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.EBICSConfig</RootNamespace>
     <Description>C# based client library for EBICS H004 and EBICS H005.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.FinTS/libfintx.FinTS.csproj
+++ b/src/libfintx.FinTS/libfintx.FinTS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.FinTS</RootNamespace>
     <Description>C# based client library for HBCI 2.2, FinTS 3.0, EBICS H004 and EBICS H005.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.Globals/libfintx.Globals.csproj
+++ b/src/libfintx.Globals/libfintx.Globals.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.Globals</RootNamespace>
     <Description>Globals for libfintx</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.Logger/libfintx.Logger.csproj
+++ b/src/libfintx.Logger/libfintx.Logger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.Logger</RootNamespace>
     <Description>Logging framework for libfintx</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.Security/libfintx.Security.csproj
+++ b/src/libfintx.Security/libfintx.Security.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.Security</RootNamespace>
     <Description>C# based client library for EBICS H004 and EBICS H005.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.Sepa/libfintx.Sepa.csproj
+++ b/src/libfintx.Sepa/libfintx.Sepa.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.Sepa</RootNamespace>
     <Description>Functions to handle the SEPA standard. Used in libfintx.FinTS.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.Settings/libfintx.Settings.csproj
+++ b/src/libfintx.Settings/libfintx.Settings.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/libfintx.StatePrinter/libfintx.StatePrinter.csproj
+++ b/src/libfintx.StatePrinter/libfintx.StatePrinter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.StatePrinter</RootNamespace>
     <Description>C# based client library for EBICS H004 and EBICS H005.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.Swift/libfintx.Swift.csproj
+++ b/src/libfintx.Swift/libfintx.Swift.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.Swift</RootNamespace>
     <Description>Functions to handle the SWIFT messages.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.Xml/libfintx.Xml.csproj
+++ b/src/libfintx.Xml/libfintx.Xml.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.Xml</RootNamespace>
     <Description>C# based client library for EBICS H004 and EBICS H005.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/libfintx.Xsd/libfintx.Xsd.csproj
+++ b/src/libfintx.Xsd/libfintx.Xsd.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>libfintx.Xsd</RootNamespace>
     <Description>C# based client library for EBICS H004 and EBICS H005.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
 ## Summary

  - Adds `net10.0` to all library projects that previously targeted `net6.0;net8.0`
  - Adds `net10.0` to library projects that targeted `netstandard2.0;net6.0;net8.0`
  - Sample, test, and tool projects are left unchanged

  ## Affected projects

  `libfintx.FinTS`, `libfintx.Globals`, `libfintx.Logger`, `libfintx.Sepa`, `libfintx.Settings`, `libfintx.Security`,
  `libfintx.StatePrinter`, `libfintx.Swift`, `libfintx.Xml`, `libfintx.Xsd`, `libfintx.EBICS`, `libfintx.EBICSConfig`