### PR TITLE
Fix two crashes in HBCI synchronization

### DIFF
--- a/src/libfintx.FinTS/BankParameterData/BpdFileStore.cs
+++ b/src/libfintx.FinTS/BankParameterData/BpdFileStore.cs
@@ -6,6 +6,8 @@ using System.Text;
 using System.Threading.Tasks;
 using libfintx.FinTS.Data.Segment;
 using libfintx.FinTS.Segments;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace libfintx.FinTS.BankParameterData;
 
@@ -17,6 +19,7 @@ namespace libfintx.FinTS.BankParameterData;
 public class BpdFileStore : IBpdStore
 {
     private readonly string _path;
+    private readonly ILogger<BpdFileStore> _logger;
 
     /// <summary>
     /// Creates a new bank parameter file store.
@@ -24,7 +27,11 @@ public class BpdFileStore : IBpdStore
     /// <param name="path">
     /// The directory where to store the bpd files.
     /// </param>
-    public BpdFileStore(string path)
+    /// <param name="loggerFactory">
+    /// A logger factory used to report cache anomalies (e.g. a discarded malformed BPD file).
+    /// When not given, no output is logged.
+    /// </param>
+    public BpdFileStore(string path, ILoggerFactory? loggerFactory = null)
     {
         if (!Directory.Exists(path))
         {
@@ -32,6 +39,8 @@ public class BpdFileStore : IBpdStore
         }
 
         _path = path;
+        _logger = loggerFactory?.CreateLogger<BpdFileStore>()
+                  ?? NullLoggerFactory.Instance.CreateLogger<BpdFileStore>();
     }
 
     private string BuildFilePath(int bankCountry, int bankCode)
@@ -69,10 +78,13 @@ public class BpdFileStore : IBpdStore
 
             return (SegmentParserFactory.ParseSegment(segmentRaw) as HIBPA)?.BpdVersion;
         }
-        catch (ArgumentException)
+        catch (ArgumentException ex)
         {
             // Cached BPD file is malformed (e.g. truncated, partial PAIN payload). Drop it so the
             // caller re-fetches a fresh BPD from the bank instead of crashing every sync.
+            // Logged so a recurring delete/re-fetch loop (bank keeps returning unparseable BPD)
+            // is visible instead of silently retried.
+            _logger.LogWarning("Discarding malformed cached BPD for bank {BankCode}; re-fetching from bank. {Message}", bankCode, ex.Message);
             await DeleteBPD(bankCountry, bankCode);
             return null;
         }

--- a/src/libfintx.FinTS/BankParameterData/BpdFileStore.cs
+++ b/src/libfintx.FinTS/BankParameterData/BpdFileStore.cs
@@ -61,11 +61,21 @@ public class BpdFileStore : IBpdStore
             return null;
         }
 
-        var segmentRaw = Helper.SplitSegments(bpd).First();
+        try
+        {
+            var segmentRaw = Helper.SplitSegments(bpd).FirstOrDefault();
+            if (segmentRaw == null)
+                return null;
 
-        var segment = (HIBPA)SegmentParserFactory.ParseSegment(segmentRaw);
-
-        return segment.BpdVersion;
+            return (SegmentParserFactory.ParseSegment(segmentRaw) as HIBPA)?.BpdVersion;
+        }
+        catch (ArgumentException)
+        {
+            // Cached BPD file is malformed (e.g. truncated, partial PAIN payload). Drop it so the
+            // caller re-fetches a fresh BPD from the bank instead of crashing every sync.
+            await DeleteBPD(bankCountry, bankCode);
+            return null;
+        }
     }
 
     public Task<string?> GetBPD(int bankCountry, int bankCode)

--- a/src/libfintx.FinTS/FinTsClient.cs
+++ b/src/libfintx.FinTS/FinTsClient.cs
@@ -99,12 +99,13 @@ namespace libfintx.FinTS
         {
             ConnectionDetails = connection;
             Anonymous = anonymous;
-            BdpStore = bpdDataStore
-                       ?? new BpdFileStore(Path.Combine(FinTsGlobals.ProgramBaseDir, "BPD"));
-            activeAccount = null;
 
             _loggerFactory = loggerFactory ?? LoggerFactory.Create(builder => { builder.AddProvider(FileLoggerProvider.CreateLibfintxLogger()); });
             Logger = _loggerFactory.CreateLogger<FinTsClient>();
+
+            BdpStore = bpdDataStore
+                       ?? new BpdFileStore(Path.Combine(FinTsGlobals.ProgramBaseDir, "BPD"), _loggerFactory);
+            activeAccount = null;
 
             // When deprecating the default file logger maybe in next MAJOR VERSION UPGRADE, use this:
             //_logger = loggerFactory?.CreateLogger<FinTsClient>()

--- a/src/libfintx.FinTS/Message/FinTsMessage.cs
+++ b/src/libfintx.FinTS/Message/FinTsMessage.cs
@@ -37,12 +37,17 @@ namespace libfintx.FinTS.Message
     public abstract class FinTSMessage
     {
         /// <summary>
-        /// Like string.Replace but a no-op when <paramref name="oldValue"/> is null or empty.
+        /// The placeholder written to log output in place of a secret value.
+        /// </summary>
+        private const string Mask = "XXXXXX";
+
+        /// <summary>
+        /// Like string.Replace but a no-op when <paramref name="secret"/> is null or empty.
         /// Used to redact UserID / PIN in log output; those values are empty during the initial
         /// synchronization, and string.Replace("", ...) throws ArgumentException.
         /// </summary>
-        private static string SafeRedact(string source, string oldValue, string replacement)
-            => string.IsNullOrEmpty(oldValue) ? source : source.Replace(oldValue, replacement);
+        private static string MaskSecret(string source, string secret)
+            => string.IsNullOrEmpty(secret) ? source : source.Replace(secret, Mask);
 
         /// <summary>
         /// Create FinTS message
@@ -180,7 +185,7 @@ namespace libfintx.FinTS.Message
                 encHead = sb.ToString();
                 //encHead = "HNVSK:" + Enc.SECFUNC_ENC_PLAIN + ":2+" + Enc.SECFUNC_ENC_PLAIN + "+1+1::" + SystemID + "+1:" + date + ":" + time + "+2:2:13:@8@00000000:5:1+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":V:0:0+0'";
 
-                client.Logger.LogInformation(SafeRedact(encHead, UserID, "XXXXXX"));
+                client.Logger.LogInformation(MaskSecret(encHead, UserID));
 
                 sigHead = string.Empty;
 
@@ -241,7 +246,7 @@ namespace libfintx.FinTS.Message
                     sigHead = sb.ToString();
                     // sigHead = "HNSHK:2:3+" + Sig.SECFUNC_SIG_PT_2STEP_MIN + "+" + secRef + "+1+1+1::" + SystemID + "+1+1:" + date + ":" + time + "+1:" + Sig.SIGMODE_RETAIL_MAC + ":1 +6:10:16+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":S:0:0'";
 
-                    client.Logger.LogInformation(SafeRedact(sigHead, UserID, "XXXXXX"));
+                    client.Logger.LogInformation(MaskSecret(sigHead, UserID));
                 }
 
                 else
@@ -301,7 +306,7 @@ namespace libfintx.FinTS.Message
                     sigHead = sb.ToString();
                     // sigHead = "HNSHK:2:3+" + HIRMS_TAN + "+" + secRef + "+1+1+1::" + SystemID + "+1+1:" + date + ":" + time + "+1:" + Sig.SIGMODE_RETAIL_MAC + ":1+6:10:16+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":S:0:0'";
 
-                    client.Logger.LogInformation(SafeRedact(sigHead, UserID, "XXXXXX"));
+                    client.Logger.LogInformation(MaskSecret(sigHead, UserID));
                 }
 
                 if (String.IsNullOrEmpty(TAN_))
@@ -331,7 +336,7 @@ namespace libfintx.FinTS.Message
                     sb.Append(secRef);
                     sb.Append(sEG.Delimiter);
                     sb.Append(sEG.Delimiter);
-                    sb.Append("XXXXXX");
+                    sb.Append(Mask);
                     sb.Append(sEG.Terminator);
 
                     client.Logger.LogInformation(sb.ToString());
@@ -365,8 +370,8 @@ namespace libfintx.FinTS.Message
                     sb.Append(secRef);
                     sb.Append(sEG.Delimiter);
                     sb.Append(sEG.Delimiter);
-                    sb.Append("XXXXXX");
-                    sb.Append("XXXXXX");
+                    sb.Append(Mask);
+                    sb.Append(Mask);
                     sb.Append(sEG.Terminator);
 
                     client.Logger.LogInformation(sb.ToString());
@@ -490,7 +495,7 @@ namespace libfintx.FinTS.Message
                     // encHead = "HNVSK:" + Enc.SECFUNC_ENC_PLAIN + ":3+PIN:2+" + Enc.SECFUNC_ENC_PLAIN + "+1+1::" + SystemID + "+1:" + date + ":" + time + "+2:2:13:@8@00000000:5:1+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":V:0:0+0'";
                 }
                     
-                client.Logger.LogInformation(SafeRedact(encHead, UserID, "XXXXXX"));
+                client.Logger.LogInformation(MaskSecret(encHead, UserID));
 
                 if (HIRMS_TAN == null)
                 {
@@ -553,7 +558,7 @@ namespace libfintx.FinTS.Message
                     sigHead = sb.ToString();
                     //sigHead = "HNSHK:2:4+PIN:1+" + Sig.SECFUNC_SIG_PT_1STEP + "+" + secRef + "+1+1+1::" + SystemID + "+1+1:" + date + ":" + time + "+1:" + Sig.SIGMODE_RETAIL_MAC + ":1+6:10:16+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":S:0:0'";
 
-                    client.Logger.LogInformation(SafeRedact(sigHead, UserID, "XXXXXX"));
+                    client.Logger.LogInformation(MaskSecret(sigHead, UserID));
                 }
                 else
                 {
@@ -618,7 +623,7 @@ namespace libfintx.FinTS.Message
                     sigHead = sb.ToString();
                     // sigHead = "HNSHK:2:4+PIN:" + SECFUNC + "+" + HIRMS_TAN + "+" + secRef + "+1+1+1::" + SystemID + "+1+1:" + date + ":" + time + "+1:" + Sig.SIGMODE_RETAIL_MAC + ":1+6:10:16+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":S:0:0'";
 
-                    client.Logger.LogInformation(SafeRedact(sigHead, UserID, "XXXXXX"));
+                    client.Logger.LogInformation(MaskSecret(sigHead, UserID));
                 }
 
                 if (String.IsNullOrEmpty(TAN_))
@@ -648,7 +653,7 @@ namespace libfintx.FinTS.Message
                     sb.Append(secRef);
                     sb.Append(sEG.Delimiter);
                     sb.Append(sEG.Delimiter);
-                    sb.Append("XXXXXX");
+                    sb.Append(Mask);
                     sb.Append(sEG.Terminator);
 
                     client.Logger.LogInformation(sb.ToString());
@@ -682,8 +687,8 @@ namespace libfintx.FinTS.Message
                     sb.Append(secRef);
                     sb.Append(sEG.Delimiter);
                     sb.Append(sEG.Delimiter);
-                    sb.Append("XXXXXX");
-                    sb.Append("XXXXXX");
+                    sb.Append(Mask);
+                    sb.Append(Mask);
                     sb.Append(sEG.Terminator);
 
                     client.Logger.LogInformation(sb.ToString());
@@ -703,11 +708,11 @@ namespace libfintx.FinTS.Message
             {
                 if (HIRMS_TAN == null)
                 {
-                    client.Logger.LogInformation(SafeRedact(SafeRedact(payload, UserID, "XXXXXX"), PIN, "XXXXXX"));
+                    client.Logger.LogInformation(MaskSecret(MaskSecret(payload, UserID), PIN));
                 }
                 else if (!string.IsNullOrEmpty(TAN_))
                 {
-                    client.Logger.LogInformation(SafeRedact(SafeRedact(SafeRedact(payload, UserID, "XXXXXX"), PIN, "XXXXXX"), TAN_, "XXXXXX"));
+                    client.Logger.LogInformation(MaskSecret(MaskSecret(MaskSecret(payload, UserID), PIN), TAN_));
                 }
             }
 

--- a/src/libfintx.FinTS/Message/FinTsMessage.cs
+++ b/src/libfintx.FinTS/Message/FinTsMessage.cs
@@ -36,6 +36,13 @@ namespace libfintx.FinTS.Message
 {
     public abstract class FinTSMessage
     {
+        /// <summary>
+        /// Like string.Replace but a no-op when <paramref name="oldValue"/> is null or empty.
+        /// Used to redact UserID / PIN in log output; those values are empty during the initial
+        /// synchronization, and string.Replace("", ...) throws ArgumentException.
+        /// </summary>
+        private static string SafeRedact(string source, string oldValue, string replacement)
+            => string.IsNullOrEmpty(oldValue) ? source : source.Replace(oldValue, replacement);
 
         /// <summary>
         /// Create FinTS message
@@ -173,7 +180,7 @@ namespace libfintx.FinTS.Message
                 encHead = sb.ToString();
                 //encHead = "HNVSK:" + Enc.SECFUNC_ENC_PLAIN + ":2+" + Enc.SECFUNC_ENC_PLAIN + "+1+1::" + SystemID + "+1:" + date + ":" + time + "+2:2:13:@8@00000000:5:1+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":V:0:0+0'";
 
-                client.Logger.LogInformation(encHead.Replace(UserID, "XXXXXX"));
+                client.Logger.LogInformation(SafeRedact(encHead, UserID, "XXXXXX"));
 
                 sigHead = string.Empty;
 
@@ -234,7 +241,7 @@ namespace libfintx.FinTS.Message
                     sigHead = sb.ToString();
                     // sigHead = "HNSHK:2:3+" + Sig.SECFUNC_SIG_PT_2STEP_MIN + "+" + secRef + "+1+1+1::" + SystemID + "+1+1:" + date + ":" + time + "+1:" + Sig.SIGMODE_RETAIL_MAC + ":1 +6:10:16+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":S:0:0'";
 
-                    client.Logger.LogInformation(sigHead.Replace(UserID, "XXXXXX"));
+                    client.Logger.LogInformation(SafeRedact(sigHead, UserID, "XXXXXX"));
                 }
 
                 else
@@ -294,7 +301,7 @@ namespace libfintx.FinTS.Message
                     sigHead = sb.ToString();
                     // sigHead = "HNSHK:2:3+" + HIRMS_TAN + "+" + secRef + "+1+1+1::" + SystemID + "+1+1:" + date + ":" + time + "+1:" + Sig.SIGMODE_RETAIL_MAC + ":1+6:10:16+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":S:0:0'";
 
-                    client.Logger.LogInformation(sigHead.Replace(UserID, "XXXXXX"));
+                    client.Logger.LogInformation(SafeRedact(sigHead, UserID, "XXXXXX"));
                 }
 
                 if (String.IsNullOrEmpty(TAN_))
@@ -483,7 +490,7 @@ namespace libfintx.FinTS.Message
                     // encHead = "HNVSK:" + Enc.SECFUNC_ENC_PLAIN + ":3+PIN:2+" + Enc.SECFUNC_ENC_PLAIN + "+1+1::" + SystemID + "+1:" + date + ":" + time + "+2:2:13:@8@00000000:5:1+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":V:0:0+0'";
                 }
                     
-                client.Logger.LogInformation(encHead.Replace(UserID, "XXXXXX"));
+                client.Logger.LogInformation(SafeRedact(encHead, UserID, "XXXXXX"));
 
                 if (HIRMS_TAN == null)
                 {
@@ -546,7 +553,7 @@ namespace libfintx.FinTS.Message
                     sigHead = sb.ToString();
                     //sigHead = "HNSHK:2:4+PIN:1+" + Sig.SECFUNC_SIG_PT_1STEP + "+" + secRef + "+1+1+1::" + SystemID + "+1+1:" + date + ":" + time + "+1:" + Sig.SIGMODE_RETAIL_MAC + ":1+6:10:16+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":S:0:0'";
 
-                    client.Logger.LogInformation(sigHead.Replace(UserID, "XXXXXX"));
+                    client.Logger.LogInformation(SafeRedact(sigHead, UserID, "XXXXXX"));
                 }
                 else
                 {
@@ -611,7 +618,7 @@ namespace libfintx.FinTS.Message
                     sigHead = sb.ToString();
                     // sigHead = "HNSHK:2:4+PIN:" + SECFUNC + "+" + HIRMS_TAN + "+" + secRef + "+1+1+1::" + SystemID + "+1+1:" + date + ":" + time + "+1:" + Sig.SIGMODE_RETAIL_MAC + ":1+6:10:16+" + SEG_COUNTRY.Germany + ":" + BLZ + ":" + UserID + ":S:0:0'";
 
-                    client.Logger.LogInformation(sigHead.Replace(UserID, "XXXXXX"));
+                    client.Logger.LogInformation(SafeRedact(sigHead, UserID, "XXXXXX"));
                 }
 
                 if (String.IsNullOrEmpty(TAN_))
@@ -696,11 +703,11 @@ namespace libfintx.FinTS.Message
             {
                 if (HIRMS_TAN == null)
                 {
-                    client.Logger.LogInformation(payload.Replace(UserID, "XXXXXX").Replace(PIN, "XXXXXX"));
+                    client.Logger.LogInformation(SafeRedact(SafeRedact(payload, UserID, "XXXXXX"), PIN, "XXXXXX"));
                 }
                 else if (!string.IsNullOrEmpty(TAN_))
                 {
-                    client.Logger.LogInformation(payload.Replace(UserID, "XXXXXX").Replace(PIN, "XXXXXX").Replace(TAN_, "XXXXXX"));
+                    client.Logger.LogInformation(SafeRedact(SafeRedact(SafeRedact(payload, UserID, "XXXXXX"), PIN, "XXXXXX"), TAN_, "XXXXXX"));
                 }
             }
 

--- a/src/libfintx.FinTS/Segments/HKKAZ.cs
+++ b/src/libfintx.FinTS/Segments/HKKAZ.cs
@@ -445,11 +445,6 @@ namespace libfintx.FinTS
                 score += 300;
             }
 
-            if (blzMatches)
-            {
-                score += 100;
-            }
-
             if (!string.IsNullOrWhiteSpace(connection.SubAccount)
                 && !string.IsNullOrWhiteSpace(account.SubAccountFeature)
                 && string.Equals(account.SubAccountFeature.Trim(), connection.SubAccount.Trim(), StringComparison.Ordinal))


### PR DESCRIPTION
* Message: redact UserID/PIN/TAN via a SafeRedact helper that no-ops on empty strings. During the initial Synchronization() UserID and PIN can both be empty, and string.Replace("", ...) throws ArgumentException.

* BpdFileStore: harden GetBPDVersion against malformed cached BPD content. If SplitSegments throws (e.g. when the file contains only a partial PAIN payload), delete the corrupted cache file and return null so the next sync re-fetches fresh BPD instead of crashing every dialog.