### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Version 1.4.0 (2026-06-09)
+
+- :rocket: add .NET 10 to the target frameworks ([#64](https://github.com/libfintx/libfintx/pull/64))
+- :rocket: complete EBICS C53 implementation and use Latin1 encoding
+- :rocket: *change* repair and reunify the `main` branch onto the maintained line ([#67](https://github.com/libfintx/libfintx/pull/67))
+- :bug: *fix* decoupled TAN (HKTAN#7) not completing when the bank sends both 0030 and 3955
+- :bug: *fix* HKTAN omitted when the bank skips BPD due to an unchanged cached version
+- :bug: *fix* HKKAZ account matching and harden UPD / segment parsing
+- :bug: *fix* two crashes in HBCI synchronization (empty UserID/PIN redaction; malformed cached BPD)
+- :bug: *fix* `BPD.Parse` crash on a null/empty cached BPD
+
 ## Version 1.3.0 (2025-01-03)
 
 - :tada: redesign BPD handling: interface IBpdStore supports now use of different BPD storeand BPD version is now retrieved from cache and send when calling Synchronization

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
   -->
 
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Authors>Torsten Klinger</Authors>
     <Copyright>Copyright © 2016 - 2024 Torsten Klinger</Copyright>
     <PackageProjectUrl>https://libfintx.github.io</PackageProjectUrl>


### PR DESCRIPTION
Bumps version `1.3.0 → 1.4.0` and updates the changelog — the first release off the repaired `main`.

Since 1.3.0 (Jan 2025, last published to NuGet): .NET 10 target, completed EBICS C53/Latin1, decoupled-TAN / HKTAN / HKKAZ fixes, BPD-store hardening, and the main-branch reconciliation (#67).

**Note:** publishing the package to NuGet additionally requires rotating the expired `NUGET_PUBLISH_API_KEY` secret (admin-only) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)