### PR TITLE
CI: run build/test on all branches; keep publish on main only

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,10 +1,10 @@
 name: .NET
 
+# Build + test run on every branch push and every pull request.
+# The publish job below is pinned to main only.
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 env:
   API_KEY: ${{ secrets.NUGET_PUBLISH_API_KEY }}
@@ -68,7 +68,8 @@ jobs:
   publish:
     needs: build
 
-    if: github.event_name != 'pull_request'
+    # Only publish from a push to main, never from other branches or pull requests.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Activates CI (build + test) on **every branch push and pull request**, while keeping the NuGet publish job restricted to `main`.

- Triggers: drop the `branches: [main]` filter on `push`/`pull_request`.
- Publish job: pin to `github.event_name == 'push' && github.ref == 'refs/heads/main'` so broadening the triggers can't publish from other branches.

Takes effect for new branches cut from `main` (they inherit the workflow) and for all PRs (which use `main`'s workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)